### PR TITLE
add template engine references

### DIFF
--- a/lib/common/utils/handlebarsEngine.js
+++ b/lib/common/utils/handlebarsEngine.js
@@ -11,6 +11,7 @@ define(['handlebars'], function (Handlebars) {
         },
         execute: function(template, context, templateName) {
             return template(context);
-        }
+        },
+        engine: Handlebars
     };
 });

--- a/lib/common/utils/template.js
+++ b/lib/common/utils/template.js
@@ -105,7 +105,8 @@ define(['utils/handlebarsEngine'], function (handlebarsEngine) {
                             },
                             execute: function (compiledTemplate, data) {
                                 return compiledTemplate(data);
-                            }
+                            },
+                            engine: _.template
                         };
                     };
             }


### PR DESCRIPTION
Added the template engine references directly to the interfaces, so that no one needs to load a template engine via a define any longer. Developers should be using `LAZO.app.getTemplateEngine` instead. This will protect them from changes such as the way that handlebars.amd is exporting in 1.3*+. It exports `{ default: Handlebars }` instead of `Handlebars`. Including Handlebars via a define will break application level code where developers are compiling client side templates when we upgrade the version in lazo. 
