### PR TITLE
serialize everything but functions and black listed attributes

### DIFF
--- a/lib/public/views/base.js
+++ b/lib/public/views/base.js
@@ -24,8 +24,7 @@ define(['jquery', 'underscore', 'backbone', 'renderer'], function ($, _, Backbon
             var data = {};
 
             for (var k in obj) { // do not use _.each; it uses hasOwnProp;
-                if ((_.isObject(obj[k]) || _.isArray(obj[k]) || _.isString(obj[k]) || _.isNumber(obj[k])) && // white list
-                    (!exceptions[k] && !_.isFunction(obj[k]))) { // black list
+                if (!exceptions[k] && !_.isFunction(obj[k])) {
                     if (k === 'models' || k === 'collections') { // serialize the models and collections from ctl.ctx
                         data[k] = {};
                         for (var j in obj[k]) {
@@ -90,15 +89,18 @@ define(['jquery', 'underscore', 'backbone', 'renderer'], function ($, _, Backbon
             return this;
         },
 
-        afterRender: function () {},
+        afterRender: function () {
+        },
 
         getInnerHtml: function () { // get view html minus this.el string wrapper
             return this._templateEngine.execute(this.template, this.serializeData(), this.templatePath);
         },
 
-        onRemove: function () {},
+        onRemove: function () {
+        },
 
-        onAttach: function () {},
+        onAttach: function () {
+        },
 
         remove: function () {
             Backbone.View.prototype.remove.call(this);
@@ -111,7 +113,7 @@ define(['jquery', 'underscore', 'backbone', 'renderer'], function ($, _, Backbon
         },
 
         // TODO: copied from old version of backbone
-        _configure: function(options) {
+        _configure: function (options) {
             if (this.options) {
                 options = _.extend({}, _.result(this, 'options'), options);
             }


### PR DESCRIPTION
We were leaving a few types behind: boolean, null and undefined. Based on how underscore evaluates each type, would be faster to just have filter out functions and black listed attributes.
