### PR TITLE
skip failing test

### DIFF
--- a/test/unit/client/common/utils/document.js
+++ b/test/unit/client/common/utils/document.js
@@ -22,7 +22,7 @@ define([
             // link.onload is not being called when test is executed in phantomjs because it
             // is not supported by the version of webkit phantomjs is running
             it('should update css', function () {
-                this.skip(); // testing failing regardless of env because link.onload never executes
+                this.skip(); // test failing regardless of env because link.onload never executes
                 // if (window.navigator.userAgent.indexOf('PhantomJS') !== -1 || window.lazoLocalTesting) {
                 //     this.skip();
                 // }


### PR DESCRIPTION
test failing regardless of env because link.onload never executes
