### PR TITLE
Log as warn

### DIFF
--- a/lib/server/handlers/app/main.js
+++ b/lib/server/handlers/app/main.js
@@ -21,7 +21,7 @@ define(['handlers/utils', 'handlers/app/processor'], function (utils, processor)
         processor.reply(route, options, {
             error: function (err) {
                 err = err instanceof Error ? err : new Error(err);
-                LAZO.logger.debug('[server.handlers.app.main.processor.reply] Error processing request...', route, options.url.href, err);
+                LAZO.logger.warn('[server.handlers.app.main.processor.reply] Error processing request...', route, options.url.href, err);
                 throw err; // hapi domain catches error
             },
             success: function (response) {


### PR DESCRIPTION
Debug can hide the error if you're not logging as debug. Moving this to warn.