### PR TITLE
Per request meta tags

### DIFF
--- a/lib/client/execute.js
+++ b/lib/client/execute.js
@@ -133,6 +133,11 @@ define(
                                 LAZO.ctl.children['lazo-layout-body'].shift();
                                 // update layout parameters
                                 _.extend(LAZO.ctl.ctx.params, ctl.ctx.params);
+                                // update meta data
+                                if (!LAZO.ctl.ctx.meta) {
+                                    LAZO.ctl.ctx.meta = {};
+                                }
+                                _.extend(LAZO.ctl.ctx.meta, ctl.ctx.meta || {}); // Required for page tags
                             }
 
                             prune(LAZO.ctl); // remove orphaned models

--- a/lib/client/execute.js
+++ b/lib/client/execute.js
@@ -153,8 +153,14 @@ define(
                                                 LAZO.logger.error('[LAZO.navigate] Error attaching views', err);
                                             }
 
-                                            doc.setTitle(LAZO.ctl.ctx._rootCtx.pageTitle);
-                                            LAZO.app.trigger('navigate:application:complete', eventData);
+                                            doc.updatePageTags(LAZO.ctl.ctx, function (err) {
+                                                if (err) {
+                                                    LAZO.logger.error('[LAZO.navigate] Error updating page tags', err);
+                                                }
+
+                                                doc.setTitle(LAZO.ctl.ctx._rootCtx.pageTitle);
+                                                LAZO.app.trigger('navigate:application:complete', eventData);
+                                            });
                                         });
                                     }, 0);
                                 }

--- a/lib/common/app.js
+++ b/lib/common/app.js
@@ -77,7 +77,7 @@ define(['requestFilters', 'underscore', 'utils/template', 'utils/model', 'utils/
         },
 
         getPageTags: function (ctx) {
-            return doc.getPageTags(ctx);
+            return doc.getPageTags(ctx, this.isServer);
         },
 
         setHtmlTag: function (val) {

--- a/lib/common/app.js
+++ b/lib/common/app.js
@@ -71,6 +71,15 @@ define(['requestFilters', 'underscore', 'utils/template', 'utils/model', 'utils/
             return this;
         },
 
+        addPageTag: function (ctx, name, attributes, content) {
+            doc.addPageTag(ctx, this.isServer, name, attributes, content);
+            return this;
+        },
+
+        getPageTags: function (ctx) {
+            return doc.getPageTags(ctx);
+        },
+
         setHtmlTag: function (val) {
             doc.setHtmlTag(val);
             return this;

--- a/lib/common/context.js
+++ b/lib/common/context.js
@@ -38,7 +38,9 @@ define(['jquery', 'underscore', 'l!jquerycookie'], function ($, _) {
             assets: {},
             collections: {},
             models: {},
-            params: {}
+            params: {},
+            meta: {},
+            headers: {}
         };
 
         // Create a copy and fill in default values

--- a/lib/common/utils/document.js
+++ b/lib/common/utils/document.js
@@ -1,4 +1,4 @@
-define(['jquery', 'async', 'underscore'], function ($, async, _) {
+define(['jquery', 'async', 'underscore', 'utils/sanitizer'], function ($, async, _, sanitizer) {
 
     'use strict';
 
@@ -38,10 +38,11 @@ define(['jquery', 'async', 'underscore'], function ($, async, _) {
         },
 
         addTag: function (name, attributes, content) {
-            tags.push(this._createTag(name, attributes, content));
+            var tag = this._createTag(name, attributes, content);
+            tags.push(tag);
 
             if (LAZO.app.isClient) {
-                this._addTagToDOM(name, attributes, content);
+                this._addTagToDOM(tag);
             }
 
             return this;
@@ -55,18 +56,20 @@ define(['jquery', 'async', 'underscore'], function ($, async, _) {
             var t = _.find(tags, function (tag) { return tag.name === 'title'; }),
                 $title;
 
+            var titleTag = this._createTag('title', {}, title);
+
             if (t) {
-                t.content = title;
+                t.content = titleTag.content;
             } else {
-                this.addTag('title', {}, title);
+                tags.push(titleTag); // prevent duplicate title tags in header
             }
 
             if (LAZO.app.isClient) {
                 $title = $('title');
                 if ($title.length) {
-                    $title.html(title);
+                    $title.html(titleTag.content); // TODO: Ensure script injection prevention, test with IE (IE Bug may prevent title being set correctly)
                 } else {
-                    this._addTagToDOM('title', {}, title);
+                    this._addTagToDOM(titleTag);
                 }
             }
 
@@ -127,17 +130,28 @@ define(['jquery', 'async', 'underscore'], function ($, async, _) {
                 ctx._rootCtx.pageTags = ctx._rootCtx.pageTags || [];
                 ctx._rootCtx.pageTags.push(pageTag);
             }
-
-            ctx.pageTags = ctx.pageTags || [];
-            ctx.pageTags.push(pageTag);
-
+            else {
+                ctx.meta = ctx.meta || {};
+                ctx.meta.pageTags = ctx.meta.pageTags || [];
+                ctx.meta.pageTags.push(pageTag);
+            }
         },
 
-        getPageTags: function (ctx) {
-            return ctx.pageTags;
+        getPageTags: function (ctx, isServer) {
+
+            if (isServer) {
+                return ctx._rootCtx.pageTags || [];
+            }
+
+            ctx.meta = ctx.meta || {};
+            return ctx.meta.pageTags || [];
         },
 
         updatePageTags: function (ctx, callback) {
+
+            if (!LAZO.app.isClient) {
+                return;
+            }
 
             var self = this;
             var addTasks = [];
@@ -147,8 +161,10 @@ define(['jquery', 'async', 'underscore'], function ($, async, _) {
                 self._removeTagFromDOM(ctx._rootCtx.pageTags.pop());
             }
 
-            while (ctx.pageTags.length > 0) {
-                var tag = ctx.pageTags.pop();
+            ctx.meta = ctx.meta || {};
+            ctx.meta.pageTags = ctx.meta.pageTags || [];
+            while (ctx.meta.pageTags.length > 0) {
+                var tag = ctx.meta.pageTags.pop();
 
                 // Add to root ctx
                 ctx._rootCtx.pageTags.push(tag);
@@ -156,7 +172,7 @@ define(['jquery', 'async', 'underscore'], function ($, async, _) {
                 (function (pageTag) {
                     addTasks.push(function (callback) {
                         // Render
-                        self._addTagToDOM(pageTag.name, pageTag.attributes, pageTag.content);
+                        self._addTagToDOM(pageTag);
                         callback();
                     });
                 })(tag);
@@ -165,6 +181,7 @@ define(['jquery', 'async', 'underscore'], function ($, async, _) {
 
             async.parallel(addTasks, function (err) {
                 if (err) {
+                    LAZO.logger.error('Failed adding page tags. %s', err);
                     return callback(err);
                 }
 
@@ -174,7 +191,7 @@ define(['jquery', 'async', 'underscore'], function ($, async, _) {
         },
 
         _createPageTag: function (name, attributes, content) {
-            return { name: name, attributes: attributes|| [], content: content  || null };
+            return this._encodeTag(name, attributes, content);
         },
 
         _createTag: function (name, attributes, content) {
@@ -182,37 +199,71 @@ define(['jquery', 'async', 'underscore'], function ($, async, _) {
 
             content = content || null;
             defaults = _.clone(tagAttributeDefaults[name] || {});
-            attributes = _.extend(defaults, attributes);
 
-            return { name: name, attributes: _.extend(defaults, attributes), content: content };
+            return this._encodeTag(name, _.extend(defaults, attributes), content);
         },
 
-        _renderTagAttributes: function (name, attributes) {
+        _encodeTag: function (name, attributes, content) {
 
-            return _.reduce(attributes || [], function(memo, val, key){
+            attributes = attributes || [];
+            var keys = _.keys(attributes);
+            var encodedAttributes = {};
+            for (var i = 0; i < keys.length; i++) {
+                var key = keys[i];
+                encodedAttributes[key] = sanitizer.encode(attributes[key]);
+            }
+
+            var encodedContent = null;
+            if (content) {
+                encodedContent = sanitizer.encode(content);
+            }
+
+            return { name: name, attributes: encodedAttributes, content: encodedContent };
+
+        },
+
+        _addTagToDOM: function (tag) {
+
+            if (!LAZO.app.isClient) {
+                return;
+            }
+
+            var self = this;
+            self.$head = self.$head || $('head');
+
+            var selector = self._getTagSelector(tag);
+            var attrStr = _.reduce(tag.attributes || [], function(memo, val, key){
                 return memo + (' ' + key + '="' + val + '"');
             }, '');
 
-        },
+            // determine if the tag already exists
+            if (self.$head.find(selector).length) {
+                LAZO.logger.debug('Duplicate tag will not be added: %s, %s, %s', tag.name, attrStr, tag.content);
+                return;
+            }
 
-        _addTagToDOM: function (name, attributes, content) {
-            this.$head = this.$head || $('head');
-            var attrStr = this._renderTagAttributes(name, attributes);
-            this.$head.append('<' + name + attrStr + '>' + (content || '') + '</' + name + '>');
+            self.$head.append('<' + tag.name + attrStr + '>' + (tag.content || '') + '</' + tag.name + '>');
         },
 
         _removeTagFromDOM: function (tag) {
 
-            if (LAZO.app.isClient) {
-
-                var self = this;
-                var attrStr = self._renderTagAttributes(tag.name, tag.attributes);
-                var selector = tag.name + attrStr + ':first';
-
-                self.$head = self.$head || $('head');
-                self.$head.find(selector).remove();
+            if (!LAZO.app.isClient) {
+                return;
             }
 
+            var self = this;
+            self.$head = self.$head || $('head');
+
+            var selector = self._getTagSelector(tag);
+            self.$head.find(selector).remove();
+
+        },
+
+        _getTagSelector: function (tag) {
+            var attrStr = _.reduce(tag.attributes, function(memo, val, key){
+                return memo + ('[' + key + '="' + val + '"]');
+            }, '');
+            return tag.name + attrStr + ':first';
         }
 
     };

--- a/lib/common/utils/document.js
+++ b/lib/common/utils/document.js
@@ -150,7 +150,7 @@ define(['jquery', 'async', 'underscore', 'utils/sanitizer'], function ($, async,
         updatePageTags: function (ctx, callback) {
 
             if (!LAZO.app.isClient) {
-                return;
+                return callback();
             }
 
             var self = this;

--- a/lib/common/utils/document.js
+++ b/lib/common/utils/document.js
@@ -118,6 +118,65 @@ define(['jquery', 'async', 'underscore'], function ($, async, _) {
             return this;
         },
 
+        addPageTag: function (ctx, isServer, name, attributes, content) {
+
+            var pageTag = this._createPageTag(name, attributes, content);
+
+            if (isServer) {
+                // Serialize the page tags to the client
+                ctx._rootCtx.pageTags = ctx._rootCtx.pageTags || [];
+                ctx._rootCtx.pageTags.push(pageTag);
+            }
+
+            ctx.pageTags = ctx.pageTags || [];
+            ctx.pageTags.push(pageTag);
+
+        },
+
+        getPageTags: function (ctx) {
+            return ctx.pageTags;
+        },
+
+        updatePageTags: function (ctx, callback) {
+
+            var self = this;
+            var addTasks = [];
+
+            ctx._rootCtx.pageTags = ctx._rootCtx.pageTags || [];
+            while (ctx._rootCtx.pageTags.length > 0) {
+                self._removeTagFromDOM(ctx._rootCtx.pageTags.pop());
+            }
+
+            while (ctx.pageTags.length > 0) {
+                var tag = ctx.pageTags.pop();
+
+                // Add to root ctx
+                ctx._rootCtx.pageTags.push(tag);
+
+                (function (pageTag) {
+                    addTasks.push(function (callback) {
+                        // Render
+                        self._addTagToDOM(pageTag.name, pageTag.attributes, pageTag.content);
+                        callback();
+                    });
+                })(tag);
+
+            }
+
+            async.parallel(addTasks, function (err) {
+                if (err) {
+                    return callback(err);
+                }
+
+                callback();
+            });
+
+        },
+
+        _createPageTag: function (name, attributes, content) {
+            return { name: name, attributes: attributes|| [], content: content  || null };
+        },
+
         _createTag: function (name, attributes, content) {
             var defaults;
 
@@ -128,12 +187,32 @@ define(['jquery', 'async', 'underscore'], function ($, async, _) {
             return { name: name, attributes: _.extend(defaults, attributes), content: content };
         },
 
-        _addTagToDOM: function (name, attributes, content) {
-            this.$head = this.$head || $('head');
-            var attrStr = _.reduce(attributes, function(memo, val, key){
+        _renderTagAttributes: function (name, attributes) {
+
+            return _.reduce(attributes || [], function(memo, val, key){
                 return memo + (' ' + key + '="' + val + '"');
             }, '');
+
+        },
+
+        _addTagToDOM: function (name, attributes, content) {
+            this.$head = this.$head || $('head');
+            var attrStr = this._renderTagAttributes(name, attributes);
             this.$head.append('<' + name + attrStr + '>' + (content || '') + '</' + name + '>');
+        },
+
+        _removeTagFromDOM: function (tag) {
+
+            if (LAZO.app.isClient) {
+
+                var self = this;
+                var attrStr = self._renderTagAttributes(tag.name, tag.attributes);
+                var selector = tag.name + attrStr + ':first';
+
+                self.$head = self.$head || $('head');
+                self.$head.find(selector).remove();
+            }
+
         }
 
     };

--- a/lib/common/utils/document.js
+++ b/lib/common/utils/document.js
@@ -131,7 +131,7 @@ define(['jquery', 'async', 'underscore'], function ($, async, _) {
         _addTagToDOM: function (name, attributes, content) {
             this.$head = this.$head || $('head');
             var attrStr = _.reduce(attributes, function(memo, val, key){
-                return memo + (' ' + key + '=' + val);
+                return memo + (' ' + key + '="' + val + '"');
             }, '');
             this.$head.append('<' + name + attrStr + '>' + (content || '') + '</' + name + '>');
         }

--- a/lib/common/utils/sanitizer.js
+++ b/lib/common/utils/sanitizer.js
@@ -1,0 +1,26 @@
+define([], function () {
+
+    'use strict';
+
+    return {
+
+        /**
+         * Encodes an entity for safe display in html element text or attributes
+         */
+        encode: function (value) {
+
+            // TODO: This should be expanded to include other scenarios.
+            // See: https://github.com/angular/angular.js/blob/v1.3.14/src/ngSanitize/sanitize.js#L435
+
+            return String(value)
+                .replace(/&/g, '&amp;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+
+        }
+
+    };
+
+});

--- a/lib/public/controller.js
+++ b/lib/public/controller.js
@@ -82,7 +82,7 @@ define([
                 assets: this.ctx.assets,
                 css: this.ctx.css,
                 headers: this.ctx.headers,
-                meta: this.ctx.meta,
+                meta: this.ctx.meta
             });
 
             if (LAZO.app.isClient) {
@@ -180,6 +180,15 @@ define([
 
         getPageTitle: function () {
             return this.ctx._rootCtx.pageTitle;
+        },
+
+        addPageTag: function (name, attributes, content) {
+            LAZO.app.addPageTag(this.ctx, name, attributes, content);
+            return this;
+        },
+
+        getPageTags: function () {
+            return LAZO.app.getPageTags(this.ctx);
         },
 
         getPath: function () {

--- a/lib/server/handlers/app/processor.js
+++ b/lib/server/handlers/app/processor.js
@@ -43,15 +43,15 @@ define(['underscore', 'requestFilters', 'renderer', 'handlers/app/html', 'utils/
             function buildHtmlResponse(rootCtx, bodyHtml) {
                 var tags;
 
-                    doc.setTitle(ctl.getPageTitle());
-                    tags = _.map(doc.getTags(), function (tag) {
-                        return _.clone(tag);
-                    });
+                doc.setTitle(ctl.getPageTitle());
+                tags = _.map(doc.getTags(), function (tag) {
+                    return _.clone(tag);
+                });
 
-                    // append the per page/request tags
-                    tags = tags.concat(_.map(ctl.getPageTags(), function (tag) {
-                        return _.clone(tag);
-                    }));
+                // append the per page/request tags
+                tags = tags.concat(_.map(ctl.getPageTags(), function (tag) {
+                    return _.clone(tag);
+                }));
 
                 function getPaths() {
                     var clientAppPaths = {};

--- a/lib/server/handlers/app/processor.js
+++ b/lib/server/handlers/app/processor.js
@@ -48,6 +48,11 @@ define(['underscore', 'requestFilters', 'renderer', 'handlers/app/html', 'utils/
                         return _.clone(tag);
                     });
 
+                    // append the per page/request tags
+                    tags = tags.concat(_.map(ctl.getPageTags(), function (tag) {
+                        return _.clone(tag);
+                    }));
+
                 function getPaths() {
                     var clientAppPaths = {};
 

--- a/test/unit/client/common/utils/document.js
+++ b/test/unit/client/common/utils/document.js
@@ -44,6 +44,51 @@ define([
                 });
             });
 
+            it('add, get page tags', function () {
+
+                var ctx = {
+                    _rootCtx: {},
+                    meta: {}
+                };
+
+                expect(doc.getPageTags(ctx, false).length).to.equal(0);
+                doc.addPageTag(ctx, false, 'meta', { description: 'text' });
+                expect(doc.getPageTags(ctx, false).length).to.equal(1);
+            });
+
+            it('updates page tags', function () {
+                var dfd = this.async();
+                var ctx = {
+                    _rootCtx: {
+                        pageTags: [
+                            { name: 'meta', attributes: { description: 'text' }, content: null },
+                            { name: 'meta', attributes: { keywords: 'keyword' }, content: null }
+                        ]
+                    },
+                    meta: {
+                        pageTags: []
+                    }
+                };
+
+                // simulate initial update on client
+                doc.updatePageTags(ctx, function (err) {
+                    expect(err).to.not.exist;
+                    expect(ctx._rootCtx.pageTags.length).to.equal(0);
+                    expect(ctx.meta.pageTags.length).to.equal(0);
+
+                    doc.addPageTag(ctx, false, 'meta', { description: 'text' });
+                    doc.addPageTag(ctx, false, 'meta', { keywords: 'keyword' });
+                    expect(ctx.meta.pageTags.length).to.equal(2);
+
+                    // simulate secondary update on client
+                    doc.updatePageTags(ctx, function (err) {
+                        expect(err).to.not.exist;
+                        expect(ctx._rootCtx.pageTags.length).to.equal(2);
+                        expect(ctx.meta.pageTags.length).to.equal(0);
+                        dfd.resolve();
+                    });
+                });
+            });
         });
     }
 });

--- a/test/unit/server/common/utils/document.js
+++ b/test/unit/server/common/utils/document.js
@@ -43,6 +43,18 @@ define([
                 expect(metaTag.attributes.name).to.be.equal('description');
                 expect(metaTag.attributes.content).to.be.equal('the most awesome web page ever');
             });
+
+            it('add, get page tags', function () {
+
+                var ctx = {
+                    _rootCtx: {},
+                    meta: {}
+                };
+
+                expect(doc.getPageTags(ctx, true).length).to.equal(0);
+                doc.addPageTag(ctx, true, 'meta', { description: 'text' });
+                expect(doc.getPageTags(ctx, true).length).to.equal(1);
+            });
         });
     }
 });


### PR DESCRIPTION
Delivers per request/page meta tags as referenced in #221 and #185 (partially) 

Page meta tags are rendered after a controller action is executed. To add a page tag from a controller action, use:
this.addPageTag([name], [attributes], [content]);

This PR also fixes a tag rendering bug where attribute values containing whitespace were not correctly rendered, and fixes a bug that resulted in multiple page title tags being rendered.
