### PR TITLE
Refactor view.resolveChild

### DIFF
--- a/lib/public/views/view.js
+++ b/lib/public/views/view.js
@@ -172,21 +172,26 @@ define(['underscore', 'backbone', 'utils/template', 'resolver/main', 'flexo', 'r
 
         resolveChild: function (viewName, options) {
             var self = this;
-            var viewNameVal = this.viewDefinitions[viewName];
-            if (!viewNameVal) {
-                options.error(new Error('Could not resolve child view, ' + viewName));
-            }
+            self.getChildren({
+                success: function (views) {
+                    var viewNameVal = views[viewName];
+                    if (!viewNameVal) {
+                        options.error(new Error('Could not resolve child view, ' + viewName));
+                    }
 
-            viewNameVal = _.isObject(viewNameVal) && viewNameVal.cid ? viewNameVal.name : viewNameVal;
-            this.loadChild(viewNameVal, {
-                error: options.error,
-                success: function (View) {
-                    self.children = self.children || {};
-                    var view = self.children[viewName] = new View(self.getChildOptions({
-                        name: viewNameVal
-                    }));
-                    options.success(view);
-                }
+                    viewNameVal = _.isObject(viewNameVal) && viewNameVal.cid ? viewNameVal.name : viewNameVal;
+                    self.loadChild(viewNameVal, {
+                        error: options.error,
+                        success: function (View) {
+                            self.children = self.children || {};
+                            var view = self.children[viewName] = new View(self.getChildOptions({
+                                name: viewNameVal
+                            }));
+                            options.success(view);
+                        }
+                    });
+                },
+                error: options.error
             });
         },
 
@@ -199,7 +204,11 @@ define(['underscore', 'backbone', 'utils/template', 'resolver/main', 'flexo', 'r
         },
 
         getChildren: function (options) {
-            options.success(_.result(this, 'viewDefinitions'));
+            if (!this.viewDefinitions) {
+                this.viewDefinitions = _.result(this, 'views', {});
+            }
+
+            options.success(this.viewDefinitions);
         },
 
         attachChildren: function (options) {


### PR DESCRIPTION
Firstly, this change allows parent views to override 'getChildren' when resolving a views child views.
It has been refactored so 'resolveChild' uses 'getChildren' to get the child views as opposed to accessing 'this.viewDefinitions' directly.

Secondly (and you may not want to do this? But it's very easy to undo), when defining child views (which is undocumented) on a parent view, change to use 'views:{}' instead of 'viewDefinitions:{}'. I did this because it is inline with the widget naming conventions. To undo this, change the text on line 208 (https://github.com/lazojs/lazo/compare/v2...adam-26:v2-prChildViews?expand=1#diff-ba20ce2426b01f0538bb84f2e63d7fe1R208) from 'views', back to 'viewDefinitions'.
