### PR TITLE
Http response data

### DIFF
--- a/lib/common/app.js
+++ b/lib/common/app.js
@@ -1,4 +1,4 @@
-define(['requestFilters', 'underscore', 'utils/template', 'utils/model', 'utils/document', 'backbone', 'base', 'bundler', 'httpResponse'],
+define(['requestFilters', 'underscore', 'utils/template', 'utils/model', 'utils/document', 'backbone', 'base', 'bundler', 'l!httpResponse'],
     function (filter, _, template, model, doc, Backbone, Base, Bundler, httpResponse) {
 
     'use strict';
@@ -122,21 +122,37 @@ define(['requestFilters', 'underscore', 'utils/template', 'utils/model', 'utils/
         },
 
         addHttpHeader: function (name, value, options) {
-            httpResponse.addHttpHeader(this.isClient, name, value, options);
+            if (this.isClient) {
+                return this;
+            }
+
+            httpResponse.addHttpHeader(name, value, options);
             return this;
         },
 
         getHttpHeaders: function () {
-            return httpResponse.getHttpHeaders(this.isClient);
+            if (this.isClient) {
+                return [];
+            }
+
+            return httpResponse.getHttpHeaders();
         },
 
         addHttpVaryParam: function (varyParam) {
-            httpResponse.addVaryParam(this.isClient, varyParam);
+            if (this.isClient) {
+                return this;
+            }
+
+            httpResponse.addVaryParam(varyParam);
             return this;
         },
 
         getHttpVaryParams: function () {
-            return httpResponse.getVaryParams(this.isClient);
+            if (this.isClient) {
+                return [];
+            }
+
+            return httpResponse.getVaryParams();
         }
 
     });

--- a/lib/common/app.js
+++ b/lib/common/app.js
@@ -1,5 +1,5 @@
-define(['requestFilters', 'underscore', 'utils/template', 'utils/model', 'utils/document', 'backbone', 'base', 'bundler'],
-    function (filter, _, template, model, doc, Backbone, Base, Bundler) {
+define(['requestFilters', 'underscore', 'utils/template', 'utils/model', 'utils/document', 'backbone', 'base', 'bundler', 'httpResponse'],
+    function (filter, _, template, model, doc, Backbone, Base, Bundler, httpResponse) {
 
     'use strict';
 
@@ -119,6 +119,24 @@ define(['requestFilters', 'underscore', 'utils/template', 'utils/model', 'utils/
 
         getImport: function (relativePath) {
             return bundle.resolveImport(relativePath, 'application');
+        },
+
+        addHttpHeader: function (name, value, options) {
+            httpResponse.addHttpHeader(this.isClient, name, value, options);
+            return this;
+        },
+
+        getHttpHeaders: function () {
+            return httpResponse.getHttpHeaders(this.isClient);
+        },
+
+        addHttpVaryParam: function (varyParam) {
+            httpResponse.addVaryParam(this.isClient, varyParam);
+            return this;
+        },
+
+        getHttpVaryParams: function () {
+            return httpResponse.getVaryParams(this.isClient);
         }
 
     });

--- a/lib/common/context.js
+++ b/lib/common/context.js
@@ -60,6 +60,7 @@ define(['jquery', 'underscore', 'l!jquerycookie'], function ($, _) {
             this._reply = options._reply;
             this.location = normalizeLocation(options._request.url, this.headers, options._request.server.info);
             this.userAgent = this.headers['user-agent'];
+            this.response = options.response;
         } else if (LAZO.app.isClient) {
             this.location = normalizeLocation(window.location);
             this.userAgent = window.navigator.userAgent;

--- a/lib/common/resolver/paths.json
+++ b/lib/common/resolver/paths.json
@@ -65,7 +65,8 @@
         "handlers": "lib/server/handlers",
         "forbidden": "lib/server/forbidden",
         "appServerSetup": "lib/public/server/server",
-        "lazoServer": "lib/public/server/server"
+        "lazoServer": "lib/public/server/server",
+        "httpResponse": "lib/server/httpResponse"
     },
     "lib": [
         "assetsProvider",

--- a/lib/common/utils/ctlSerializor.js
+++ b/lib/common/utils/ctlSerializor.js
@@ -7,8 +7,8 @@ define(['underscore', 'lazoModel'], function (_, Model) {
         serialize: function (ctl, rootCtx) {
             var serObj = {},
                 viewRef,
-                omit = rootCtx ? ['cookies', '_request', '_reply', 'models', 'collections', 'location', 'userAgent', 'headers'] :
-                    ['cookies', '_request', '_reply', 'models', 'collections', '_rootCtx', 'location', 'userAgent', 'headers'];
+                omit = rootCtx ? ['cookies', '_request', '_reply', 'models', 'collections', 'location', 'userAgent', 'headers', 'response'] :
+                    ['cookies', '_request', '_reply', 'models', 'collections', '_rootCtx', 'location', 'userAgent', 'headers', 'response'];
 
             serObj.cid = ctl.cid;
             serObj.ctx = _.omit(ctl.ctx, omit);

--- a/lib/common/utils/module.js
+++ b/lib/common/utils/module.js
@@ -76,7 +76,7 @@ define(['resolver/file', 'underscore', 'text', 'context', 'utils/loader', 'async
             }
 
             childOptions = _.defaults(_.pick(options, 'action', 'rootComponent'), defaults);
-            childContext = new Context(_.extend({}, _.pick(parent.ctx, ['_rootCtx', '_request', 'headers', 'meta']), {
+            childContext = new Context(_.extend({}, _.pick(parent.ctx, ['_rootCtx', '_request', 'headers', 'meta', 'response']), {
                 params : options.params }));
 
             if (parent.ctx && parent.ctx._rootCtx) {

--- a/lib/public/controller.js
+++ b/lib/public/controller.js
@@ -226,6 +226,61 @@ define([
             return bundle.resolveImport(relativePath, this.name);
         },
 
+        setHttpStatusCode: function (statusCode) {
+            if (LAZO.app.isClient) {
+                return this;
+            }
+
+            if (!_.isFinite(statusCode) || statusCode < 0) {
+                throw new Error('statusCode is invalid, it must be a positive integer.');
+            }
+
+            this.ctx.response.statusCode = statusCode;
+            return this;
+        },
+
+        getHttpStatusCode: function () {
+            if (LAZO.app.isClient) {
+                return null;
+            }
+
+            return this.ctx.response.statusCode || 200;
+        },
+
+        addHttpHeader: function (name, value, options) {
+            if (LAZO.app.isClient) {
+                return null;
+            }
+
+            this.ctx.response.httpHeaders.push({ name: name, value: value, options: options || null });
+            return this;
+        },
+
+        getHttpHeaders: function () {
+            if (LAZO.app.isClient) {
+                return [];
+            }
+
+            return this.ctx.response.httpHeaders || [];
+        },
+
+        addHttpVaryParam: function (varyParam) {
+            if (LAZO.app.isClient) {
+                return null;
+            }
+
+            this.ctx.response.varyParams.push(varyParam);
+            return this;
+        },
+
+        getHttpVaryParams: function () {
+            if (LAZO.app.isClient) {
+                return [];
+            }
+
+            return this.ctx.response.varyParams || [];
+        },
+
         _getEl: function () {
             if (LAZO.app.isClient) {
                 return $('[lazo-cmp-id="' + this.cid + '"]');

--- a/lib/public/controller.js
+++ b/lib/public/controller.js
@@ -249,7 +249,7 @@ define([
 
         addHttpHeader: function (name, value, options) {
             if (LAZO.app.isClient) {
-                return null;
+                return this;
             }
 
             this.ctx.response.httpHeaders.push({ name: name, value: value, options: options || null });
@@ -266,7 +266,7 @@ define([
 
         addHttpVaryParam: function (varyParam) {
             if (LAZO.app.isClient) {
-                return null;
+                return this;
             }
 
             this.ctx.response.varyParams.push(varyParam);

--- a/lib/server/handlers/app/main.js
+++ b/lib/server/handlers/app/main.js
@@ -1,4 +1,4 @@
-define(['handlers/utils', 'handlers/app/processor'], function (utils, processor) {
+define(['handlers/utils', 'handlers/app/processor', 'underscore', 'httpResponse'], function (utils, processor, _, httpResponse) {
 
     return function (request, reply, route, svr) {
         var payload = request.payload;
@@ -12,8 +12,9 @@ define(['handlers/utils', 'handlers/app/processor'], function (utils, processor)
                 LAZO.logger.warn('[server.handlers.app.main.processor.reply] Error processing request...', route, options.url.href, err);
                 throw err; // hapi domain catches error
             },
-            success: function (response) {
-                reply(response);
+            success: function (html, httpResponseData) {
+                var response = reply(html);
+                httpResponse.applyHttpResponseData(response, httpResponseData);
             }
         });
     };

--- a/lib/server/handlers/app/processor.js
+++ b/lib/server/handlers/app/processor.js
@@ -1,5 +1,5 @@
-define(['underscore', 'requestFilters', 'renderer', 'handlers/app/html', 'utils/document', 'bundler', 'utils/cmpProcessor'],
-    function (_, filter, renderer, html, doc, Bundler, cmpProcessor) {
+define(['underscore', 'requestFilters', 'renderer', 'handlers/app/html', 'utils/document', 'bundler', 'utils/cmpProcessor', 'httpResponse'],
+    function (_, filter, renderer, html, doc, Bundler, cmpProcessor, httpResponse) {
 
     'use strict';
 
@@ -92,7 +92,7 @@ define(['underscore', 'requestFilters', 'renderer', 'handlers/app/html', 'utils/
                     if (isDevelopment) {
                         ctx._rootCtx.dependencies.css = bundle._createCSSLinks(LAZO.app.css.slice(0).concat(ctx._rootCtx.dependencies.css));
                         ctx._rootCtx.dependencies.imports = bundle._createImportLinks(LAZO.app.imports.slice(0).concat(ctx._rootCtx.dependencies.imports));
-                        return options.success(buildHtmlResponse(rootCtx, bodyHtml));
+                        return options.success(buildHtmlResponse(rootCtx, bodyHtml), httpResponse.mergeHttpResponseData(ctl));
                     }
 
                     bundle.response(route, ctl.ctx.location.pathname, {
@@ -106,7 +106,7 @@ define(['underscore', 'requestFilters', 'renderer', 'handlers/app/html', 'utils/
                                 rootCtx.dependencies.imports = bundle.sortImports(bundle._createImportLinks(LAZO.app.imports.slice(0).concat(ctx._rootCtx.dependencies.imports)));
                             }
 
-                            options.success(buildHtmlResponse(rootCtx, bodyHtml));
+                            options.success(buildHtmlResponse(rootCtx, bodyHtml), httpResponse.mergeHttpResponseData(ctl));
                         },
                         error: function (err) {
                             throw err instanceof Error ? err : new Error(err);

--- a/lib/server/handlers/utils.js
+++ b/lib/server/handlers/utils.js
@@ -53,7 +53,12 @@ define(['underscore'], function (_) {
                 _request: request,
                 _reply: reply,
                 headers: this.getHeaders(request),
-                url: this.getParsedUrl(request)
+                url: this.getParsedUrl(request),
+                response: {
+                    statusCode: null,
+                    httpHeaders: [],
+                    varyParams: []
+                }
             };
         }
 

--- a/lib/server/httpResponse.js
+++ b/lib/server/httpResponse.js
@@ -1,0 +1,67 @@
+define(['underscore'], function (_) {
+
+    'use strict';
+
+    var httpHeaders = [],
+        varyHeader = [];
+
+    return {
+
+        addHttpHeader: function (isClient, name, value, options) {
+            if (isClient) {
+                return this;
+            }
+
+            httpHeaders.push({ name: name, value: value, options: options });
+            return this;
+        },
+
+        getHttpHeaders: function (isClient) {
+            if (isClient) {
+                return [];
+            }
+
+            return httpHeaders;
+        },
+
+        addVaryParam: function (isClient, varyParam) {
+            if (isClient) {
+                return this;
+            }
+
+            varyHeader.push(varyParam);
+            return this;
+        },
+
+        getVaryParams: function (isClient) {
+            if (isClient) {
+                return [];
+            }
+
+            return varyHeader;
+        },
+
+        mergeHttpResponseData: function (ctl) {
+            return {
+                statusCode: ctl.getHttpStatusCode() || null,
+                httpHeaders: httpHeaders.concat(ctl.getHttpHeaders()),
+                varyParams: _.union(varyHeader, ctl.getHttpVaryParams())
+            };
+        },
+
+        applyHttpResponseData: function (response, httpResponseData) {
+            if (httpResponseData.statusCode) {
+                response.code(httpResponseData.statusCode);
+            }
+
+            _.each(httpResponseData.httpHeaders, function (header) {
+                response.header(header.name, header.value, header.options || { override: true });
+            });
+
+            _.each(httpResponseData.varyParams, function (headerName) {
+                response.vary(headerName);
+            });
+        }
+
+    }
+});

--- a/lib/server/httpResponse.js
+++ b/lib/server/httpResponse.js
@@ -7,37 +7,21 @@ define(['underscore'], function (_) {
 
     return {
 
-        addHttpHeader: function (isClient, name, value, options) {
-            if (isClient) {
-                return this;
-            }
-
+        addHttpHeader: function (name, value, options) {
             httpHeaders.push({ name: name, value: value, options: options });
             return this;
         },
 
-        getHttpHeaders: function (isClient) {
-            if (isClient) {
-                return [];
-            }
-
+        getHttpHeaders: function () {
             return httpHeaders;
         },
 
-        addVaryParam: function (isClient, varyParam) {
-            if (isClient) {
-                return this;
-            }
-
+        addVaryParam: function (varyParam) {
             varyHeader.push(varyParam);
             return this;
         },
 
-        getVaryParams: function (isClient) {
-            if (isClient) {
-                return [];
-            }
-
+        getVaryParams: function () {
             return varyHeader;
         },
 

--- a/lib/server/httpResponse.js
+++ b/lib/server/httpResponse.js
@@ -8,7 +8,7 @@ define(['underscore'], function (_) {
     return {
 
         addHttpHeader: function (name, value, options) {
-            httpHeaders.push({ name: name, value: value, options: options });
+            httpHeaders.push({ name: name, value: value, options: options || null });
             return this;
         },
 

--- a/test/unit/client-server/public/controller.js
+++ b/test/unit/client-server/public/controller.js
@@ -38,7 +38,7 @@ define([
                         expect(controller.getHttpHeaders().length).to.equal(0);
                         dfd.resolve();
                     },
-                    error: function (err) {
+                    error: function () {
                         dfd.reject();
                     }
                 });
@@ -52,7 +52,7 @@ define([
                         expect(controller.getHttpVaryParams().length).to.equal(0);
                         dfd.resolve();
                     },
-                    error: function (err) {
+                    error: function () {
                         dfd.reject();
                     }
                 });

--- a/test/unit/client-server/public/controller.js
+++ b/test/unit/client-server/public/controller.js
@@ -1,0 +1,63 @@
+define([
+    'intern!bdd',
+    'intern/chai!',
+    'intern/chai!expect',
+    'sinon',
+    'sinon-chai',
+    'test/unit/utils',
+    'lazoCtl'
+], function (bdd, chai, expect, sinon, sinonChai, utils, LazoController) {
+    chai.use(sinonChai);
+
+    with (bdd) {
+        describe('Lazo Controller', function () {
+
+            var controller;
+
+            var getController = function (options) {
+                var ctlOptions = {
+                    name: 'home',
+                    ctx: {
+                        response: {
+                            statusCode: null,
+                            httpHeaders: [],
+                            varyParams: []
+                        }
+                    }
+                };
+
+                var MyController = LazoController.extend({});
+                MyController.create('home', ctlOptions, options);
+            };
+
+            it('should have empty http header values', function () {
+                var dfd = this.async();
+                getController({
+                    success: function (myController) {
+                        controller = myController;
+                        expect(controller.getHttpHeaders().length).to.equal(0);
+                        dfd.resolve();
+                    },
+                    error: function (err) {
+                        dfd.reject();
+                    }
+                });
+            });
+
+            it('should have empty http vary params', function () {
+                var dfd = this.async();
+                getController({
+                    success: function (myController) {
+                        controller = myController;
+                        expect(controller.getHttpVaryParams().length).to.equal(0);
+                        dfd.resolve();
+                    },
+                    error: function (err) {
+                        dfd.reject();
+                    }
+                });
+            });
+
+        });
+    }
+});

--- a/test/unit/client/common/app.js
+++ b/test/unit/client/common/app.js
@@ -1,0 +1,40 @@
+define([
+    'intern!bdd',
+    'intern/chai!',
+    'intern/chai!expect',
+    'sinon',
+    'sinon-chai',
+    'test/unit/utils',
+    'lazoApp'
+], function (bdd, chai, expect, sinon, sinonChai, utils, LazoApp) {
+    chai.use(sinonChai);
+
+    with (bdd) {
+        describe('Lazo Application - client', function () {
+
+            it('should no-op on add http vary params', function () {
+
+                var lazoApp = new LazoApp({});
+                lazoApp.isClient = true;
+                expect(lazoApp.getHttpVaryParams().length).to.equal(0);
+                var app = lazoApp.addHttpVaryParam('user-agent');
+
+                var params = lazoApp.getHttpVaryParams();
+                expect(params.length).to.equal(0);
+                expect(app == lazoApp).to.be.true;
+
+            });
+
+            it('should no-op on add http headers', function () {
+                var lazoApp = new LazoApp({});
+                lazoApp.isClient = true;
+                expect(lazoApp.getHttpHeaders().length).to.equal(0);
+                var app = lazoApp.addHttpHeader('X-Frame-Options', 'deny');
+
+                var headers = lazoApp.getHttpHeaders();
+                expect(headers.length).to.equal(0);
+                expect(app == lazoApp).to.be.true;
+            });
+        });
+    }
+});

--- a/test/unit/conf.client.local.js
+++ b/test/unit/conf.client.local.js
@@ -57,7 +57,7 @@ define(['intern/dojo/text!lib/common/resolver/paths.json', 'test/mocks/lazo', 'i
                     // testing libs
                     sinon: '../../node_modules/sinon/lib/sinon.js',
                     'sinon-chai': '../../node_modules/sinon-chai/lib/sinon-chai.js',
-                    bundler: '../lib/public/bundle'
+                    'bundler': 'lazoBundle'
                 }
             }
         },

--- a/test/unit/conf.client.local.js
+++ b/test/unit/conf.client.local.js
@@ -56,7 +56,8 @@ define(['intern/dojo/text!lib/common/resolver/paths.json', 'test/mocks/lazo', 'i
                 '*': {
                     // testing libs
                     sinon: '../../node_modules/sinon/lib/sinon.js',
-                    'sinon-chai': '../../node_modules/sinon-chai/lib/sinon-chai.js'
+                    'sinon-chai': '../../node_modules/sinon-chai/lib/sinon-chai.js',
+                    bundler: '../lib/public/bundle'
                 }
             }
         },

--- a/test/unit/conf.client.phantomjs.js
+++ b/test/unit/conf.client.phantomjs.js
@@ -51,7 +51,8 @@ define(['intern/dojo/text!lib/common/resolver/paths.json', 'test/mocks/lazo', 'i
                 '*': {
                     // testing libs
                     sinon: '../../node_modules/sinon/lib/sinon.js',
-                    'sinon-chai': '../../node_modules/sinon-chai/lib/sinon-chai.js'
+                    'sinon-chai': '../../node_modules/sinon-chai/lib/sinon-chai.js',
+                    bundler: '../lib/public/bundle'
                 }
             }
         }

--- a/test/unit/conf.client.phantomjs.js
+++ b/test/unit/conf.client.phantomjs.js
@@ -52,7 +52,7 @@ define(['intern/dojo/text!lib/common/resolver/paths.json', 'test/mocks/lazo', 'i
                     // testing libs
                     sinon: '../../node_modules/sinon/lib/sinon.js',
                     'sinon-chai': '../../node_modules/sinon-chai/lib/sinon-chai.js',
-                    bundler: '../lib/public/bundle'
+                    'bundler': 'lazoBundle'
                 }
             }
         }

--- a/test/unit/conf.server.js
+++ b/test/unit/conf.server.js
@@ -31,7 +31,7 @@ define(['intern/dojo/text!lib/common/resolver/paths.json', 'test/mocks/lazo'], f
         excludeInstrumentation: /^(?:test|node_modules|lib\/vendor)\//,
 
         useLoader: {
-            'host-node': 'requirejs',
+            'host-node': 'requirejs'
         },
 
         loader: {
@@ -45,7 +45,8 @@ define(['intern/dojo/text!lib/common/resolver/paths.json', 'test/mocks/lazo'], f
                     // mocks
                     request: 'test/mocks/server/request',
                     'continuation-local-storage': 'test/mocks/server/continuation-local-storage',
-                    hapi: 'test/mocks/server/hapi'
+                    hapi: 'test/mocks/server/hapi',
+                    bundler: 'lib/public/bundle'
                 }
             }
         }

--- a/test/unit/conf.server.js
+++ b/test/unit/conf.server.js
@@ -46,7 +46,7 @@ define(['intern/dojo/text!lib/common/resolver/paths.json', 'test/mocks/lazo'], f
                     request: 'test/mocks/server/request',
                     'continuation-local-storage': 'test/mocks/server/continuation-local-storage',
                     hapi: 'test/mocks/server/hapi',
-                    bundler: 'lib/public/bundle'
+                    'bundler': 'lazoBundle'
                 }
             }
         }

--- a/test/unit/server/common/app.js
+++ b/test/unit/server/common/app.js
@@ -1,0 +1,44 @@
+define([
+    'intern!bdd',
+    'intern/chai!',
+    'intern/chai!expect',
+    'sinon',
+    'sinon-chai',
+    'test/unit/utils',
+    'lazoApp'
+], function (bdd, chai, expect, sinon, sinonChai, utils, LazoApp) {
+    chai.use(sinonChai);
+
+    with (bdd) {
+        describe('Lazo Application - server', function () {
+
+            it('should add http vary params', function () {
+
+                var lazoApp = new LazoApp({});
+                lazoApp.isServer = true;
+                expect(lazoApp.getHttpVaryParams().length).to.equal(0);
+                var app = lazoApp.addHttpVaryParam('user-agent');
+
+                var params = lazoApp.getHttpVaryParams();
+                expect(params.length).to.equal(1);
+                expect(params[0]).to.equal('user-agent');
+                expect(app == lazoApp).to.be.true;
+
+            });
+
+            it('should add http headers', function () {
+                var lazoApp = new LazoApp({});
+                lazoApp.isServer = true;
+                expect(lazoApp.getHttpHeaders().length).to.equal(0);
+                var app = lazoApp.addHttpHeader('X-Frame-Options', 'deny');
+
+                var headers = lazoApp.getHttpHeaders();
+                expect(headers.length).to.equal(1);
+                expect(headers[0].name).to.equal('X-Frame-Options');
+                expect(headers[0].value).to.equal('deny');
+                expect(headers[0].options).to.equal(null);
+                expect(app == lazoApp).to.be.true;
+            });
+        });
+    }
+});

--- a/test/unit/server/common/app.js
+++ b/test/unit/server/common/app.js
@@ -16,11 +16,11 @@ define([
 
                 var lazoApp = new LazoApp({});
                 lazoApp.isServer = true;
-                expect(lazoApp.getHttpVaryParams().length).to.equal(0);
+                var count = lazoApp.getHttpVaryParams().length;
                 var app = lazoApp.addHttpVaryParam('user-agent');
 
                 var params = lazoApp.getHttpVaryParams();
-                expect(params.length).to.equal(1);
+                expect(params.length).to.equal(count + 1);
                 expect(params[0]).to.equal('user-agent');
                 expect(app == lazoApp).to.be.true;
 
@@ -29,11 +29,11 @@ define([
             it('should add http headers', function () {
                 var lazoApp = new LazoApp({});
                 lazoApp.isServer = true;
-                expect(lazoApp.getHttpHeaders().length).to.equal(0);
+                var count = lazoApp.getHttpHeaders().length;
                 var app = lazoApp.addHttpHeader('X-Frame-Options', 'deny');
 
                 var headers = lazoApp.getHttpHeaders();
-                expect(headers.length).to.equal(1);
+                expect(headers.length).to.equal(count + 1);
                 expect(headers[0].name).to.equal('X-Frame-Options');
                 expect(headers[0].value).to.equal('deny');
                 expect(headers[0].options).to.equal(null);

--- a/test/unit/server/httpResponse.js
+++ b/test/unit/server/httpResponse.js
@@ -1,0 +1,76 @@
+define([
+    'intern!bdd',
+    'intern/chai!',
+    'intern/chai!expect',
+    'sinon',
+    'sinon-chai',
+    'test/unit/utils',
+    'httpResponse',
+    'lazoCtl'
+], function (bdd, chai, expect, sinon, sinonChai, utils, httpResponse, LazoController) {
+    chai.use(sinonChai);
+
+    with (bdd) {
+        describe('httpResponse', function () {
+
+            var getController = function (options) {
+                var ctlOptions = {
+                    name: 'home',
+                    ctx: {
+                        response: {
+                            statusCode: null,
+                            httpHeaders: [],
+                            varyParams: []
+                        }
+                    }
+                };
+
+                var MyController = LazoController.extend({});
+                MyController.create('home', ctlOptions, options);
+            };
+
+            it('can add httpHeader', function () {
+
+                expect(httpResponse.getHttpHeaders().length).to.equal(0);
+                httpResponse.addHttpHeader('X-Frame-Options', 'deny');
+                expect(httpResponse.getHttpHeaders().length).to.equal(1);
+
+            });
+
+            it('can add vary param', function () {
+
+                expect(httpResponse.getHttpVaryParams().length).to.equal(0);
+                httpResponse.addHttpVaryParam('user-agent');
+                expect(httpResponse.getHttpVaryParams().length).to.equal(1);
+
+            });
+
+            it('can merge http response data', function () {
+
+                var dfd = this.async();
+                getController({
+                    success: function (myController) {
+                        var controller = myController;
+
+                        controller.setHttpStatusCode(410);
+                        controller.addHttpHeader('X-XSS-Protection', '1; mode=block');
+                        controller.addHttpVaryParam('accept');
+
+                        var responseData = httpResponse.mergeHttpResponseData(controller);
+                        expect(responseData).to.exist;
+                        expect(responseData.statusCode).to.equal(410);
+                        expect(responseData.httpHeaders.length).to.equal(2);
+                        expect(responseData.varyParams.length).to.equal(2);
+
+                        dfd.resolve();
+                    },
+                    error: function () {
+                        dfd.reject();
+                    }
+                });
+
+            });
+
+        });
+    }
+});

--- a/test/unit/server/httpResponse.js
+++ b/test/unit/server/httpResponse.js
@@ -31,17 +31,17 @@ define([
 
             it('can add httpHeader', function () {
 
-                expect(httpResponse.getHttpHeaders().length).to.equal(0);
+                var count = httpResponse.getHttpHeaders().length;
                 httpResponse.addHttpHeader('X-Frame-Options', 'deny');
-                expect(httpResponse.getHttpHeaders().length).to.equal(1);
+                expect(httpResponse.getHttpHeaders().length).to.equal(count + 1);
 
             });
 
             it('can add vary param', function () {
 
-                expect(httpResponse.getHttpVaryParams().length).to.equal(0);
-                httpResponse.addHttpVaryParam('user-agent');
-                expect(httpResponse.getHttpVaryParams().length).to.equal(1);
+                var count = httpResponse.getVaryParams().length;
+                httpResponse.addVaryParam('user-agent');
+                expect(httpResponse.getVaryParams().length).to.equal(count + 1);
 
             });
 
@@ -51,6 +51,8 @@ define([
                 getController({
                     success: function (myController) {
                         var controller = myController;
+                        var headerCount = httpResponse.getHttpHeaders().length;
+                        var varyCount = httpResponse.getVaryParams().length;
 
                         controller.setHttpStatusCode(410);
                         controller.addHttpHeader('X-XSS-Protection', '1; mode=block');
@@ -59,8 +61,8 @@ define([
                         var responseData = httpResponse.mergeHttpResponseData(controller);
                         expect(responseData).to.exist;
                         expect(responseData.statusCode).to.equal(410);
-                        expect(responseData.httpHeaders.length).to.equal(2);
-                        expect(responseData.varyParams.length).to.equal(2);
+                        expect(responseData.httpHeaders.length).to.equal(headerCount + 1);
+                        expect(responseData.varyParams.length).to.equal(varyCount + 1);
 
                         dfd.resolve();
                     },

--- a/test/unit/server/public/controller.js
+++ b/test/unit/server/public/controller.js
@@ -34,8 +34,9 @@ define([
                     success: function (controller) {
 
                         expect(controller.getHttpStatusCode()).to.equal(200);
-                        controller.setHttpStatusCode(410);
+                        var ctl = controller.setHttpStatusCode(410);
                         expect(controller.getHttpStatusCode()).to.equal(410);
+                        expect(ctl == controller).to.be.true;
 
                         dfd.resolve();
                     },
@@ -51,11 +52,12 @@ define([
                     success: function (controller) {
 
                         expect(controller.getHttpVaryParams().length).to.equal(0);
-                        controller.addHttpVaryParam('user-agent');
+                        var ctl = controller.addHttpVaryParam('user-agent');
 
                         var params = controller.getHttpVaryParams();
                         expect(params.length).to.equal(1);
                         expect(params[0]).to.equal('user-agent');
+                        expect(ctl == controller).to.be.true;
 
                         dfd.resolve();
                     },
@@ -71,13 +73,14 @@ define([
                     success: function (controller) {
 
                         expect(controller.getHttpHeaders().length).to.equal(0);
-                        controller.addHttpHeader('X-Frame-Options', 'deny');
+                        var ctl = controller.addHttpHeader('X-Frame-Options', 'deny');
 
                         var headers = controller.getHttpHeaders();
                         expect(headers.length).to.equal(1);
                         expect(headers[0].name).to.equal('X-Frame-Options');
                         expect(headers[0].value).to.equal('deny');
                         expect(headers[0].options).to.equal(null);
+                        expect(ctl == controller).to.be.true;
 
                         dfd.resolve();
                     },

--- a/test/unit/server/public/controller.js
+++ b/test/unit/server/public/controller.js
@@ -1,0 +1,92 @@
+define([
+    'intern!bdd',
+    'intern/chai!',
+    'intern/chai!expect',
+    'sinon',
+    'sinon-chai',
+    'test/unit/utils',
+    'lazoCtl'
+], function (bdd, chai, expect, sinon, sinonChai, utils, LazoController) {
+    chai.use(sinonChai);
+
+    with (bdd) {
+        describe('Lazo Controller', function () {
+
+            var getController = function (options) {
+                var ctlOptions = {
+                    name: 'home',
+                    ctx: {
+                        response: {
+                            statusCode: null,
+                            httpHeaders: [],
+                            varyParams: []
+                        }
+                    }
+                };
+
+                var MyController = LazoController.extend({});
+                MyController.create('home', ctlOptions, options);
+            };
+
+            it('should get/set the http status code', function () {
+                var dfd = this.async();
+                getController({
+                    success: function (controller) {
+
+                        expect(controller.getHttpStatusCode()).to.equal(200);
+                        controller.setHttpStatusCode(410);
+                        expect(controller.getHttpStatusCode()).to.equal(410);
+
+                        dfd.resolve();
+                    },
+                    error: function () {
+                        dfd.reject();
+                    }
+                });
+            });
+
+            it('should add http vary params', function () {
+                var dfd = this.async();
+                getController({
+                    success: function (controller) {
+
+                        expect(controller.getHttpVaryParams().length).to.equal(0);
+                        controller.addHttpVaryParam('user-agent');
+
+                        var params = controller.getHttpVaryParams();
+                        expect(params.length).to.equal(1);
+                        expect(params[0]).to.equal('user-agent');
+
+                        dfd.resolve();
+                    },
+                    error: function () {
+                        dfd.reject();
+                    }
+                });
+            });
+
+            it('should add http headers', function () {
+                var dfd = this.async();
+                getController({
+                    success: function (controller) {
+
+                        expect(controller.getHttpHeaders().length).to.equal(0);
+                        controller.addHttpHeader('X-Frame-Options', 'deny');
+
+                        var headers = controller.getHttpHeaders();
+                        expect(headers.length).to.equal(1);
+                        expect(headers[0].name).to.equal('X-Frame-Options');
+                        expect(headers[0].value).to.equal('deny');
+                        expect(headers[0].options).to.equal(null);
+
+                        dfd.resolve();
+                    },
+                    error: function () {
+                        dfd.reject();
+                    }
+                });
+            });
+
+        });
+    }
+});


### PR DESCRIPTION
Add ability to modify HTTP response data when rendering pages on the server. On the client, all functions are no-op'd.

HTTP Status Code (from a controller - applied to the current request):
this.setHttpStatusCode(410);
this.getHttpStatusCode();

HTTP Headers (from a controller - applied to the current request)
this.addHttpHeader('name', 'value', {options});
this.getHttpHeaders();

HTTP Headers (applied to every request)
LAZO.app.addHttpHeader('name', 'value' {options});
LAZO.app.getHttpHeaders();

HTTP vary header (from a controller - applied to the current request)
this.addHttpVaryParam('user-agent');
this.getHttpVaryParams();

HTTP vary header (applied to every request)
LAZO.app.addHttpVaryParam('user-agent');
LAZO.app.getHttpVaryParams();

To better understand the http header options, please refer to the HAPI docs http://hapijs.com/api/6.4.0#response-object. All headers are processed using the 'header' function on the HAPI response object.