### PR TITLE
Collection items (models) missing name parameter

### DIFF
--- a/lib/public/collection.js
+++ b/lib/public/collection.js
@@ -55,22 +55,32 @@ define(['underscore', 'backbone', 'proxy', 'lazoModel'], function (_, Backbone, 
 
         // taken directly from Backbone.Collection._prepareModel, except where noted by comments
         _prepareModel: function(attrs, options) {
+
+            // begin lazo specific overrides
+            var modelName = null;
+            if (this.modelName) {
+                if (_.isFunction(this.modelName)) {
+                    modelName = this.modelName(attrs, options);
+                }
+                else {
+                    modelName = this.modelName;
+                }
+            }
+            // end lazo specific overrides
+
             if (attrs instanceof Backbone.Model) {
                 if (!attrs.collection) attrs.collection = this;
+                if (!attrs.name && modelName) attrs.name = modelName; // lazo specific
                 return attrs;
             }
             options || (options = {});
             options.collection = this;
 
             // begin lazo specific overrides
-            if (this.modelName) {
-                if (_.isFunction(this.modelName)) {
-                    options.name = this.modelName(attrs, options);
-                }
-                else {
-                    options.name = this.modelName;
-                }
+            if (modelName) {
+                options.name = modelName;
             }
+
             options.ctx = this.ctx;
             // end lazo specific overrides
 

--- a/test/unit/client-server/public/collection.js
+++ b/test/unit/client-server/public/collection.js
@@ -1,0 +1,32 @@
+define([
+    'intern!bdd',
+    'intern/chai!',
+    'intern/chai!expect',
+    'sinon',
+    'sinon-chai',
+    'test/unit/utils',
+    'lazoModel',
+    'lazoCollection'
+], function (bdd, chai, expect, sinon, sinonChai, utils, LazoModel, LazoCollection) {
+    chai.use(sinonChai);
+
+    with (bdd) {
+        describe('publicCollection', function () {
+
+            it('should assign the correct model name to collection items', function () {
+
+                var ChildModel = LazoModel.extend({});
+                var ParentCollection = LazoCollection.extend({
+                    model: ChildModel
+                });
+
+                var parent = new ParentCollection(null, { modelName: 'childModel' });
+                parent.add(new ChildModel({ id: 1 }, {}));
+
+                expect(parent.models[0].name).to.exist;
+            });
+
+        });
+
+    }
+});


### PR DESCRIPTION
When a model is added to a collection using collection.add(), the model is not assigned a 'name' property. This causes view attributes to be incorrectly rendered.

I'm not sure if this is the best solution, but this fix ensure any models added to a collection have the model name assigned.
