### PR TITLE
Bug fix: view transition delay when layout has not changed

### DIFF
--- a/lib/client/execute.js
+++ b/lib/client/execute.js
@@ -122,6 +122,9 @@ define(
                             var imports = state.getAddRemoveLinks('imports');
                             prime(css.add, 'css', false); // prefetch css
 
+                            // keep dimensions, but hide content so that new css updating does not cause any display issues
+                            $target.css({ 'visibility': 'hidden', 'min-height': $target.outerHeight(true) || $target.height() });
+
                             if (hasLayoutChanged) {
                                 destroy(LAZO.ctl); // clean up previous root controller
                                 delete LAZO.ctl;
@@ -150,9 +153,12 @@ define(
                                     } else {
                                         $target.html(html);
                                     }
+
+                                    // Make it visible here, to minimize visual delay experienced by user
+                                    $target.css({ 'visibility': 'visible', 'min-height': '' } );
+
                                     setTimeout(function () {
                                         LAZO.error.clear();
-                                        $target.css({ 'visibility': 'visible'} );
                                         viewManager.attachViews(ctl, function (err, success) {
                                             if (err) {
                                                 LAZO.logger.error('[LAZO.navigate] Error attaching views', err);
@@ -171,8 +177,6 @@ define(
                                 }
                             }
 
-                            // keep dimensions, but hide content so that new css updating does not cause any display issues
-                            $target.css({ 'visibility': 'hidden' });
                             doc.updateLinks(imports.add, imports.remove, 'import', function () {
                                 linksTypesLoaded++;
                                 onLinksDone(linksTypesLoaded);


### PR DESCRIPTION
Fix view transition delay. When the UI layout has not changed a short delay is seen by the user and the UI looks "jumpy" due to children components being removed before the view is hidden (see the `destroy()` fn). By temporarily assigning a min-height and hiding the current view before children are removed, the UI no longer jumps when navigating between views with the same layout.