### PR TITLE
Client sync events

### DIFF
--- a/lib/client/proxy.js
+++ b/lib/client/proxy.js
@@ -18,6 +18,7 @@ define(['base', 'resolver/model', 'backbone'], function (Base, helpers, Backbone
             var error = options.error;
             options.error = function (jqXHR) {
                 LAZO.logger.debug('[client.proxy.sync] Call to CRUD syncher failed', self.name, method);
+                self.trigger('error', self, jqXHR, options);
 
                 if (error) {
                     var resp = {
@@ -32,12 +33,13 @@ define(['base', 'resolver/model', 'backbone'], function (Base, helpers, Backbone
             // Replace options.success with a wrapper.
             var success = options.success;
             options.success = function (resp, textStatus, jqXHR) {
-                LAZO.logger.debug('[client.proxy.sync] Call to CRUD syncher succeed', self.name, method, resp, textStatus);
-
                 if (!resp || !resp.data) {
+                    self.trigger('error', self, jqXHR, options);
                     return options.error(jqXHR);
                 }
 
+                LAZO.logger.debug('[client.proxy.sync] Call to CRUD syncher succeed', self.name, method, resp, textStatus);
+                self.trigger('sync', self, jqXHR, options);
                 if (success && resp) {
                     success(resp.data);
                 }
@@ -96,6 +98,7 @@ define(['base', 'resolver/model', 'backbone'], function (Base, helpers, Backbone
             var error = options.error;
             options.error = function (jqXHR, textStatus, errorThrown) {
                 LAZO.logger.debug('[client.proxy.sync] Call to NON-CRUD syncher failed', self.name, fname, textStatus, errorThrown);
+                self.trigger('error', self, jqXHR, options);
 
                 if (error) {
                     error(jqXHR);
@@ -106,10 +109,12 @@ define(['base', 'resolver/model', 'backbone'], function (Base, helpers, Backbone
             var success = options.success;
             options.success = function (resp, textStatus, jqXHR) {
                 if (!resp) {
+                    self.trigger('error', self, jqXHR, options);
                     return options.error(jqXHR);
                 }
 
                 LAZO.logger.debug('[client.proxy.sync] Call to NON-CRUD syncher succeed', self.name, fname, textStatus);
+                self.trigger('sync', self, jqXHR, options);
 
                 if (success && resp) {
                     success(resp);
@@ -151,6 +156,7 @@ define(['base', 'resolver/model', 'backbone'], function (Base, helpers, Backbone
             params.data = JSON.stringify(data);
 
             var xhr = $.ajax(_.extend(params, options));
+            self.trigger('request', model, xhr, options);
         }
 
     });

--- a/lib/client/proxy.js
+++ b/lib/client/proxy.js
@@ -18,7 +18,6 @@ define(['base', 'resolver/model', 'backbone'], function (Base, helpers, Backbone
             var error = options.error;
             options.error = function (jqXHR) {
                 LAZO.logger.debug('[client.proxy.sync] Call to CRUD syncher failed', self.name, method);
-                self.trigger('error', self, jqXHR, options);
 
                 if (error) {
                     var resp = {
@@ -33,13 +32,11 @@ define(['base', 'resolver/model', 'backbone'], function (Base, helpers, Backbone
             // Replace options.success with a wrapper.
             var success = options.success;
             options.success = function (resp, textStatus, jqXHR) {
+                LAZO.logger.debug('[client.proxy.sync] Call to CRUD syncher succeed', self.name, method, resp, textStatus);
                 if (!resp || !resp.data) {
-                    self.trigger('error', self, jqXHR, options);
                     return options.error(jqXHR);
                 }
 
-                LAZO.logger.debug('[client.proxy.sync] Call to CRUD syncher succeed', self.name, method, resp, textStatus);
-                self.trigger('sync', self, jqXHR, options);
                 if (success && resp) {
                     success(resp.data);
                 }
@@ -98,7 +95,7 @@ define(['base', 'resolver/model', 'backbone'], function (Base, helpers, Backbone
             var error = options.error;
             options.error = function (jqXHR, textStatus, errorThrown) {
                 LAZO.logger.debug('[client.proxy.sync] Call to NON-CRUD syncher failed', self.name, fname, textStatus, errorThrown);
-                self.trigger('error', self, jqXHR, options);
+                self.trigger('callError', self, jqXHR, options);
 
                 if (error) {
                     error(jqXHR);
@@ -109,12 +106,12 @@ define(['base', 'resolver/model', 'backbone'], function (Base, helpers, Backbone
             var success = options.success;
             options.success = function (resp, textStatus, jqXHR) {
                 if (!resp) {
-                    self.trigger('error', self, jqXHR, options);
+                    self.trigger('callError', self, jqXHR, options);
                     return options.error(jqXHR);
                 }
 
                 LAZO.logger.debug('[client.proxy.sync] Call to NON-CRUD syncher succeed', self.name, fname, textStatus);
-                self.trigger('sync', self, jqXHR, options);
+                self.trigger('callSync', self, jqXHR, options);
 
                 if (success && resp) {
                     success(resp);
@@ -156,7 +153,7 @@ define(['base', 'resolver/model', 'backbone'], function (Base, helpers, Backbone
             params.data = JSON.stringify(data);
 
             var xhr = $.ajax(_.extend(params, options));
-            self.trigger('request', model, xhr, options);
+            self.trigger('callRequest', model, xhr, options);
         }
 
     });


### PR DESCRIPTION
Add standard backbone sync events to client proxy. Currently, these events are not triggered on the client.

I attempted to include some unit tests, however sinonjs fake XmlHttpRequests feature (http://sinonjs.org/docs/#server) does not play nicely with requirejs.