### PR TITLE
Modify client state so set() does not delete other state data.

### DIFF
--- a/lib/client/state.js
+++ b/lib/client/state.js
@@ -11,7 +11,8 @@ define(['utils/document'], function (doc) {
 
         set: function (rootCtx) {
             var url = window.location.pathname + window.location.search;
-            LAZO.router.updateState(this.createStateObj(rootCtx), url);
+            var item = LAZO.router.getItem(url) || {};
+            LAZO.router.updateState(_.extend(_.clone(item.state || {}), this.createStateObj(rootCtx)), url);
         },
 
         getAddRemoveLinks: function (type) {

--- a/test/unit/client/state.js
+++ b/test/unit/client/state.js
@@ -36,7 +36,8 @@ define([
                             dependencies: {
                                 css: [{ href: 'c.css' }],
                                 imports: [{ href: 'c.html' }]
-                            }
+                            },
+                            title: 'pageTitle'
                         }
                 };
 
@@ -84,9 +85,11 @@ define([
 
                 expect(state.get(window.location.pathname + window.location.search).state.dependencies.css.length).to.be.equal(1);
                 expect(state.get(window.location.pathname + window.location.search).state.dependencies.imports.length).to.be.equal(1);
+                expect(state.get(window.location.pathname + window.location.search).state.title).to.equal('pageTitle');
                 state.set(ctx);
                 expect(state.get(window.location.pathname + window.location.search).state.dependencies.css.length).to.be.equal(2);
                 expect(state.get(window.location.pathname + window.location.search).state.dependencies.imports.length).to.be.equal(2);
+                expect(state.get(window.location.pathname + window.location.search).state.title).to.equal('pageTitle');
             });
 
             it('should get the css to add and remove', function () {


### PR DESCRIPTION
Hi,

Currently, setting client state deletes any other data that may exist in state. This fix simply appends the new data to the state object.