### PR TITLE
HTTP response data for tunnel requests

### DIFF
--- a/lib/client/context.js
+++ b/lib/client/context.js
@@ -1,0 +1,33 @@
+define(['lib/common/context', 'jquery', 'underscore', 'l!jquerycookie'], function (Context, $, _) {
+
+    'use strict';
+
+    // do not encode or decode cookie values
+    $.cookie.raw = true;
+
+    var ClientContext = Context.extend({
+
+        constructor: function (options) {
+            Context.prototype.constructor.call(this, options);
+
+            this.location = Context.normalizeLocation(window.location);
+            this.userAgent = window.navigator.userAgent;
+        },
+
+        getCookie: function (name) {
+            return $.cookie(name);
+        },
+
+        setCookie: function (name, value, options) {
+            $.cookie(name, value, options);
+        },
+
+        clearCookie: function (name, options) {
+            $.removeCookie(name, _.extend({ path: '/' }, options));
+        }
+
+    });
+
+    return ClientContext;
+
+});

--- a/lib/client/context.js
+++ b/lib/client/context.js
@@ -1,4 +1,4 @@
-define(['lib/common/context', 'jquery', 'underscore', 'l!jquerycookie'], function (Context, $, _) {
+define(['commonContext', 'jquery', 'underscore', 'l!jquerycookie'], function (Context, $, _) {
 
     'use strict';
 

--- a/lib/common/context.js
+++ b/lib/common/context.js
@@ -1,76 +1,39 @@
-define(['jquery', 'underscore', 'l!jquerycookie'], function ($, _) {
+define(['base', 'underscore'], function (Base, _) {
 
     'use strict';
 
-    if (LAZO.isClient) {
-        // do not encode or decode cookie values
-        $.cookie.raw = true;
-    }
+    var Context = Base.extend({
 
-    function normalizeLocation(location, headers, info) {
-        var keys = ['host', 'hostname', 'search', 'href', 'pathname', 'port', 'protocol'];
-        var retVal = _.pick(location, keys);
-        var host;
+        constructor: function(options) {
+            var defaults = {
+                _rootCtx: {
+                    modelList: {},
+                    modelInstances: {},
+                    data: options && options.data ? options.data : {},
+                    pageTitle: options && options.pageTitle ? options.pageTitle : LAZO.app.defaultTitle
+                },
+                assets: {},
+                collections: {},
+                models: {},
+                params: {},
+                meta: {},
+                headers: {}
+            };
 
-        if (headers && headers.host) {
-            host = headers.host.split(':');
-            retVal.host = headers.host;
-            retVal.hostname = host[0];
-            retVal.port = host[1];
-        }
+            // Create a copy and fill in default values
+            options = _.defaults(_.extend({}, options), defaults);
 
-        if(info){
-            retVal.protocol = info.protocol;
-        }
+            this.assets = options.assets;
+            this.collections = options.collections;
+            this.models = options.models;
+            this.params = _.extend({}, options.params);
+            this.meta = options.meta;
+            this.headers = options.headers;
 
+            // Root context
+            this._rootCtx = options._rootCtx;
+        },
 
-        return retVal;
-    }
-
-    function Context(options) {
-        var defaults = {
-            _rootCtx: {
-                modelList: {},
-                modelInstances: {},
-                data: options && options.data ? options.data : {},
-                pageTitle: options && options.pageTitle ? options.pageTitle : LAZO.app.defaultTitle
-            },
-            assets: {},
-            collections: {},
-            models: {},
-            params: {},
-            meta: {},
-            headers: {}
-        };
-
-        // Create a copy and fill in default values
-        options = _.defaults(_.extend({}, options), defaults);
-
-        this.assets = options.assets;
-        this.collections = options.collections;
-        this.models = options.models;
-        this.params = _.extend({}, options.params);
-        this.meta = options.meta;
-        this.headers = options.headers;
-
-        // Root context
-        this._rootCtx = options._rootCtx;
-
-        if (LAZO.app.isServer && options._request) {
-            // Do not serialize this!
-            this._request = options._request;
-            this._reply = options._reply;
-            this.location = normalizeLocation(options._request.url, this.headers, options._request.server.info);
-            this.userAgent = this.headers['user-agent'];
-            this.isTunnelRequest = options.isTunnelRequest || false;
-            this.response = options.response;
-        } else if (LAZO.app.isClient) {
-            this.location = normalizeLocation(window.location);
-            this.userAgent = window.navigator.userAgent;
-        }
-    }
-
-    Context.prototype = {
         setSharedData: function (key, val) {
             this._rootCtx.data[key] = val;
             return this;
@@ -78,34 +41,33 @@ define(['jquery', 'underscore', 'l!jquerycookie'], function ($, _) {
 
         getSharedData: function (key) {
             return this._rootCtx.data[key];
-        },
-
-        getCookie: function (name) {
-            if (LAZO.app.isServer) {
-                return this._request.state[name] ? this._request.state[name] : undefined;
-            } else {
-                return $.cookie(name);
-            }
-        },
-
-        setCookie: function (name, value, options) {
-            if (LAZO.app.isServer) {
-                options.ttl = options.expires || null;
-                this._reply.state(name, value, options);
-            } else {
-                $.cookie(name, value, options);
-            }
-        },
-
-        clearCookie: function (name, options) {
-            if (LAZO.app.isServer) {
-                this._reply.state(name, null, _.extend({ ttl: 0, path: '/' }, options));
-            } else {
-                $.removeCookie(name, _.extend({ path: '/' }, options));
-            }
         }
 
-    };
+    }, {
+        // static props
+
+        normalizeLocation: function (location, headers, info) {
+            var keys = ['host', 'hostname', 'search', 'href', 'pathname', 'port', 'protocol'];
+            var retVal = _.pick(location, keys);
+            var host;
+
+            if (headers && headers.host) {
+                host = headers.host.split(':');
+                retVal.host = headers.host;
+                retVal.hostname = host[0];
+                retVal.port = host[1];
+            }
+
+            if(info){
+                retVal.protocol = info.protocol;
+            }
+
+
+            return retVal;
+
+        }
+    });
 
     return Context;
+
 });

--- a/lib/common/resolver/paths.json
+++ b/lib/common/resolver/paths.json
@@ -5,6 +5,7 @@
         "base": "lib/common/base",
         "config": "lib/common/config",
         "context": "lib/{env}/context",
+        "commonContext": "lib/common/context",
         "renderer": "lib/common/renderer",
         "text": "lib/vendor/text",
         "json": "lib/vendor/json",

--- a/lib/common/resolver/paths.json
+++ b/lib/common/resolver/paths.json
@@ -4,7 +4,7 @@
         "async": "lib/vendor/async",
         "base": "lib/common/base",
         "config": "lib/common/config",
-        "context": "lib/common/context",
+        "context": "lib/{env}/context",
         "renderer": "lib/common/renderer",
         "text": "lib/vendor/text",
         "json": "lib/vendor/json",

--- a/lib/public/controller.js
+++ b/lib/public/controller.js
@@ -240,11 +240,7 @@ define([
                 return this;
             }
 
-            if (!_.isFinite(statusCode) || statusCode < 0) {
-                throw new Error('statusCode is invalid, it must be a positive integer.');
-            }
-
-            this.ctx.response.statusCode = statusCode;
+            this.ctx.setHttpStatusCode(statusCode);
             return this;
         },
 
@@ -253,7 +249,7 @@ define([
                 return null;
             }
 
-            return this.ctx.response.statusCode || 200;
+            this.ctx.getHttpStatusCode();
         },
 
         addHttpHeader: function (name, value, options) {
@@ -261,7 +257,7 @@ define([
                 return this;
             }
 
-            this.ctx.response.httpHeaders.push({ name: name, value: value, options: options || null });
+            this.ctx.addHttpHeader(name, value, options);
             return this;
         },
 
@@ -270,7 +266,7 @@ define([
                 return [];
             }
 
-            return this.ctx.response.httpHeaders || [];
+            return this.ctx.getHttpHeaders();
         },
 
         addHttpVaryParam: function (varyParam) {
@@ -278,7 +274,7 @@ define([
                 return this;
             }
 
-            this.ctx.response.varyParams.push(varyParam);
+            this.ctx.addHttpVaryParam(varyParam);
             return this;
         },
 
@@ -287,7 +283,8 @@ define([
                 return [];
             }
 
-            return this.ctx.response.varyParams || [];
+            // return this.ctx.response.varyParams || [];
+            return this.ctx.getHttpVaryParams();
         },
 
         _getEl: function () {

--- a/lib/public/controller.js
+++ b/lib/public/controller.js
@@ -249,7 +249,7 @@ define([
                 return null;
             }
 
-            this.ctx.getHttpStatusCode();
+            return this.ctx.getHttpStatusCode();
         },
 
         addHttpHeader: function (name, value, options) {

--- a/lib/public/server/syncher.js
+++ b/lib/public/server/syncher.js
@@ -71,6 +71,61 @@ define(['l!base', 'l!serviceProxy'], function (Base, ServiceProxy) {
          */
         destroy: function (options) {
             throw new Error('destroy method not implemented provided');
+        },
+
+        setHttpStatusCode: function (statusCode) {
+            if (!this.proxy.ctx.isTunnelRequest) {
+                return this;
+            }
+
+            if (!_.isFinite(statusCode) || statusCode < 0) {
+                throw new Error('statusCode is invalid, it must be a positive integer.');
+            }
+
+            this.proxy.ctx.setHttpStatusCode(statusCode);
+            return this;
+        },
+
+        getHttpStatusCode: function (statusCode) {
+            if (!this.proxy.ctx.isTunnelRequest) {
+                return null;
+            }
+
+            return this.proxy.ctx.getHttpStatusCode(statusCode);
+        },
+
+        addHttpHeader: function (name, value, options) {
+            if (!this.proxy.ctx.isTunnelRequest) {
+                return this;
+            }
+
+            this.proxy.ctx.addHttpHeader(name, value, options);
+            return this;
+        },
+
+        getHttpHeaders: function () {
+            if (!this.proxy.ctx.isTunnelRequest) {
+                return [];
+            }
+
+            return this.proxy.ctx.getHttpHeaders();
+        },
+
+        addHttpVaryParam: function (varyParam) {
+            if (!this.proxy.ctx.isTunnelRequest) {
+                return this;
+            }
+
+            this.proxy.ctx.addHttpVaryParam(varyParam);
+            return this;
+        },
+
+        getHttpVaryParams: function () {
+            if (!this.proxy.ctx.isTunnelRequest) {
+                return [];
+            }
+
+            return this.proxy.ctx.getHttpVaryParams();
         }
 
     });

--- a/lib/public/server/syncher.js
+++ b/lib/public/server/syncher.js
@@ -78,10 +78,6 @@ define(['l!base', 'l!serviceProxy'], function (Base, ServiceProxy) {
                 return this;
             }
 
-            if (!_.isFinite(statusCode) || statusCode < 0) {
-                throw new Error('statusCode is invalid, it must be a positive integer.');
-            }
-
             this.proxy.ctx.setHttpStatusCode(statusCode);
             return this;
         },

--- a/lib/server/context.js
+++ b/lib/server/context.js
@@ -1,0 +1,64 @@
+define(['lib/common/context', 'underscore'], function (Context, _) {
+
+    'use strict';
+
+    var ServerContext = Context.extend({
+
+        constructor: function (options) {
+            Context.prototype.constructor.call(this, options);
+
+            // Do not serialize this!
+            this._request = options._request;
+            this._reply = options._reply;
+            this.location = Context.normalizeLocation(options._request.url, this.headers, options._request.server.info);
+            this.userAgent = this.headers['user-agent'];
+            this.isTunnelRequest = options.isTunnelRequest || false;
+            this.response = options.response;
+        },
+
+        getCookie: function (name) {
+            return this._request.state[name] ? this._request.state[name] : undefined;
+        },
+
+        setCookie: function (name, value, options) {
+            options.ttl = options.expires || null;
+            this._reply.state(name, value, options);
+        },
+
+        clearCookie: function (name, options) {
+            this._reply.state(name, null, _.extend({ ttl: 0, path: '/' }, options));
+        },
+
+        setHttpStatusCode: function (statusCode) {
+            if (!_.isFinite(statusCode) || statusCode < 0) {
+                throw new Error('statusCode is invalid, it must be a positive integer.');
+            }
+
+            this.response.statusCode = statusCode;
+        },
+
+        getHttpStatusCode: function (statusCode) {
+            return this.response.statusCode || statusCode || 200;
+        },
+
+        addHttpHeader: function (name, value, options) {
+            this.response.httpHeaders.push({ name: name, value: value, options: options || null });
+        },
+
+        getHttpHeaders: function () {
+            return this.response.httpHeaders || [];
+        },
+
+        addHttpVaryParam: function (varyParam) {
+            this.response.varyParams.push(varyParam);
+        },
+
+        getHttpVaryParams: function () {
+            return this.response.varyParams || [];
+        }
+
+    });
+
+    return ServerContext;
+
+});

--- a/lib/server/context.js
+++ b/lib/server/context.js
@@ -1,4 +1,4 @@
-define(['lib/common/context', 'underscore'], function (Context, _) {
+define(['commonContext', 'underscore'], function (Context, _) {
 
     'use strict';
 

--- a/lib/server/handlers/tunnel.js
+++ b/lib/server/handlers/tunnel.js
@@ -1,12 +1,27 @@
-define(['utils/modelLoader', 'context', 'handlers/utils'], function (modelLoader, Context, utils) {
+define(['utils/modelLoader', 'context', 'handlers/utils', 'httpResponse'], function (modelLoader, Context, utils, httpResponse) {
 
     'use strict';
 
     return function (req, reply) {
-        var handleTunnelError = function (req, response) {
+        var handleTunnelResponse = function (ctx, response, statusCode) {
+            httpResponse.applyHttpResponseData(reply(response), httpResponse.getTunnelHttpResponseData(ctx, statusCode));
+        };
+
+        var handleTunnelCallError = function (ctx, response) {
             var respText = response.body || response.error || '';
-            var resp = reply(respText);
-            resp.code(response.statusCode || 500);
+            handleTunnelResponse(ctx, respText, response.statusCode || 500);
+        };
+
+        var handleTunnelCallSuccess = function (ctx, response) {
+            handleTunnelResponse(ctx, response, 200);
+        };
+
+        var handleTunnelSyncSuccess = function (model, response) {
+            handleTunnelCallSuccess(model.ctx, { gmid: model._getGlobalId(), data: model.toJSON() });
+        };
+
+        var handleTunnelSyncError = function (model, response) {
+            handleTunnelCallError(model.ctx, response);
         };
 
         var method = req.payload.method;
@@ -21,6 +36,7 @@ define(['utils/modelLoader', 'context', 'handlers/utils'], function (modelLoader
                 loadFunc = LAZO.app.loadCollection;
                 loadName = req.payload.collection;
             }
+
             loadFunc.call(LAZO.app,
                 loadName,
                 {
@@ -29,11 +45,11 @@ define(['utils/modelLoader', 'context', 'handlers/utils'], function (modelLoader
                     })),
                     params: req.payload.params,
                     success: function (model) {
-                        reply({ gmid: model._getGlobalId(), data: model.toJSON() });
+                        handleTunnelSyncSuccess(model, {});
                     },
                     error: function (model, response, options) {
                         LAZO.logger.error('[server.handlers.tunnel] Loading %s, error processing request %j', loadName, response);
-                        handleTunnelError(req, response);
+                        handleTunnelSyncError(model, response);
                     }
                 }
             );
@@ -66,10 +82,10 @@ define(['utils/modelLoader', 'context', 'handlers/utils'], function (modelLoader
                 if (method === 'DELETE') {
                     m.destroy({
                         success: function (model, response, options) {
-                            reply({ gmid: model._getGlobalId(), data: model.toJSON() });
+                            handleTunnelSyncSuccess(model, response);
                         },
                         error: function (model, response, options) {
-                            handleTunnelError(req, response);
+                            handleTunnelSyncError(model, response);
                         }
                     });
                 }
@@ -78,10 +94,10 @@ define(['utils/modelLoader', 'context', 'handlers/utils'], function (modelLoader
                         args = payload.args;
                     m.call(fname, args, {
                         success: function (response) {
-                            reply(response);
+                            handleTunnelCallSuccess(m.ctx, response);
                         },
                         error: function (response) {
-                            handleTunnelError(req, response);
+                            handleTunnelCallError(m.ctx, response);
                         }
                     });
                 }
@@ -89,10 +105,10 @@ define(['utils/modelLoader', 'context', 'handlers/utils'], function (modelLoader
                     m.save({},
                         {
                             success: function (model, response, options) {
-                                reply({ gmid: model._getGlobalId(), data: model.toJSON() });
+                                handleTunnelSyncSuccess(model, response);
                             },
                             error: function (model, response, options) {
-                                handleTunnelError(req, response);
+                                handleTunnelSyncError(model, response);
                             }
                         });
                 }

--- a/lib/server/httpResponse.js
+++ b/lib/server/httpResponse.js
@@ -33,6 +33,14 @@ define(['underscore'], function (_) {
             };
         },
 
+        getTunnelHttpResponseData: function (ctx, statusCode) {
+            return {
+                statusCode: ctx.getHttpStatusCode(statusCode),
+                httpHeaders: ctx.getHttpHeaders(),
+                varyParams: ctx.getHttpVaryParams()
+            };
+        },
+
         applyHttpResponseData: function (response, httpResponseData) {
             if (httpResponseData.statusCode) {
                 response.code(httpResponseData.statusCode);

--- a/test/unit/client-server/public/controller.js
+++ b/test/unit/client-server/public/controller.js
@@ -22,6 +22,12 @@ define([
                             statusCode: null,
                             httpHeaders: [],
                             varyParams: []
+                        },
+                        getHttpHeaders: function () {
+                            return [];
+                        },
+                        getHttpVaryParams: function () {
+                            return [];
                         }
                     }
                 };

--- a/test/unit/server/context.js
+++ b/test/unit/server/context.js
@@ -12,6 +12,32 @@ define([
     with (bdd) {
         describe('Context', function () {
 
+            var ctxOptions = {
+                _request: {
+                    url: {
+                        pathname: 'foo/bar/baz'
+                    },
+                    raw: { // this is expected on the server
+                        req: {
+                            headers: {
+                                host: 'localhost:8080'
+                            }
+                        }
+                    },
+                    server: {
+                        info: {
+                            protocol: 'http'
+                        }
+                    }
+                },
+                headers: {},
+                response: {
+                    statusCode: null,
+                    httpHeaders: [],
+                    varyParams: []
+                }
+            };
+
             it('common server', function () {
                 var ctx = new Context({
                     _request: {
@@ -62,6 +88,31 @@ define([
                 });
 
                 expect(ctx.location.host).to.be.undefined;
+            });
+
+            it('should get/set http statusCode', function () {
+                var ctx = new Context(ctxOptions);
+
+                expect(ctx.getHttpStatusCode(302)).to.equal(302);
+                expect(ctx.getHttpStatusCode()).to.equal(200);
+                ctx.setHttpStatusCode(410);
+                expect(ctx.getHttpStatusCode()).to.equal(410);
+            });
+
+            it('should get/add http headers', function () {
+                var ctx = new Context(ctxOptions);
+
+                expect(ctx.getHttpHeaders().length).to.equal(0);
+                ctx.addHttpHeader('accept', 'text/plain');
+                expect(ctx.getHttpHeaders().length).to.equal(1);
+            });
+
+            it('should get/add http vary params', function () {
+                var ctx = new Context(ctxOptions);
+
+                expect(ctx.getHttpVaryParams().length).to.equal(0);
+                ctx.addHttpVaryParam('accept');
+                expect(ctx.getHttpVaryParams().length).to.equal(1);
             });
 
         });

--- a/test/unit/server/handlers/tunnel.js
+++ b/test/unit/server/handlers/tunnel.js
@@ -46,6 +46,11 @@ define([
 
                 LAZO.app.loadModel = function (fname, opts) {
                     opts.success({
+                        ctx: {
+                            getHttpStatusCode: function () {},
+                            getHttpHeaders: function () {},
+                            getHttpVaryParams: function () {}
+                        },
                         _getGlobalId: function () {},
                         toJSON: function () {}
                     });
@@ -86,6 +91,11 @@ define([
 
                 var stub = sinon.stub(LazoModel.prototype, 'destroy', function (opts) {
                             opts.success({
+                                ctx: {
+                                    getHttpStatusCode: function () {},
+                                    getHttpHeaders: function () {},
+                                    getHttpVaryParams: function () {}
+                                },
                                 _getGlobalId: function () {},
                                 toJSON: function () {}
                             });
@@ -131,6 +141,11 @@ define([
 
                 var stub = sinon.stub(LazoModel.prototype, 'save', function (args, opts) {
                     opts.success({
+                        ctx: {
+                            getHttpStatusCode: function () {},
+                            getHttpHeaders: function () {},
+                            getHttpVaryParams: function () {}
+                        },
                         _getGlobalId: function () {},
                         toJSON: function () {}
                     });
@@ -198,6 +213,12 @@ define([
 
                     stub.restore();
                     dfd.resolve();
+
+                    return {
+                        code: function () {},
+                        header: function () {},
+                        vary: function () {},
+                    };
                 };
 
                 Tunnel(req, reply);

--- a/test/unit/server/httpResponse.js
+++ b/test/unit/server/httpResponse.js
@@ -54,15 +54,22 @@ define([
                         var headerCount = httpResponse.getHttpHeaders().length;
                         var varyCount = httpResponse.getVaryParams().length;
 
-                        controller.setHttpStatusCode(410);
-                        controller.addHttpHeader('X-XSS-Protection', '1; mode=block');
-                        controller.addHttpVaryParam('accept');
+                        var getHttpStatusCodeStub = sinon.stub(controller, 'getHttpStatusCode').returns(410);
+                        var getHttpHeadersStub = sinon.stub(controller, 'getHttpHeaders').returns({name: 'X-XSS-Protection', value: '1; mode=block'});
+                        var getHttpVaryParamsStub = sinon.stub(controller, 'getHttpVaryParams').returns(['accept']);
 
                         var responseData = httpResponse.mergeHttpResponseData(controller);
                         expect(responseData).to.exist;
                         expect(responseData.statusCode).to.equal(410);
                         expect(responseData.httpHeaders.length).to.equal(headerCount + 1);
                         expect(responseData.varyParams.length).to.equal(varyCount + 1);
+                        expect(getHttpStatusCodeStub.calledOnce).to.be.true;
+                        expect(getHttpHeadersStub.calledOnce).to.be.true;
+                        expect(getHttpVaryParamsStub.calledOnce).to.be.true;
+
+                        getHttpStatusCodeStub.restore();
+                        getHttpHeadersStub.restore();
+                        getHttpVaryParamsStub.restore();
 
                         dfd.resolve();
                     },

--- a/test/unit/server/public/controller.js
+++ b/test/unit/server/public/controller.js
@@ -28,15 +28,48 @@ define([
                 MyController.create('home', ctlOptions, options);
             };
 
-            it('should get/set the http status code', function () {
+            it('should get the http status code', function () {
                 var dfd = this.async();
                 getController({
                     success: function (controller) {
 
-                        expect(controller.getHttpStatusCode()).to.equal(200);
-                        var ctl = controller.setHttpStatusCode(410);
-                        expect(controller.getHttpStatusCode()).to.equal(410);
-                        expect(ctl == controller).to.be.true;
+                        controller.ctx.getHttpStatusCode = sinon.stub();
+                        controller.getHttpStatusCode();
+                        expect(controller.ctx.getHttpStatusCode.calledOnce).to.be.true;
+
+                        dfd.resolve();
+                    },
+                    error: function () {
+                        dfd.reject();
+                    }
+                });
+            });
+
+            it('should set the http status code', function () {
+                var dfd = this.async();
+                getController({
+                    success: function (controller) {
+
+                        controller.ctx.setHttpStatusCode = sinon.stub();
+                        controller.setHttpStatusCode(410);
+                        expect(controller.ctx.setHttpStatusCode.calledOnce).to.be.true;
+
+                        dfd.resolve();
+                    },
+                    error: function () {
+                        dfd.reject();
+                    }
+                });
+            });
+
+            it('should get http vary params', function () {
+                var dfd = this.async();
+                getController({
+                    success: function (controller) {
+
+                        controller.ctx.getHttpVaryParams = sinon.stub();
+                        controller.getHttpVaryParams();
+                        expect(controller.ctx.getHttpVaryParams.calledOnce).to.be.true;
 
                         dfd.resolve();
                     },
@@ -51,13 +84,9 @@ define([
                 getController({
                     success: function (controller) {
 
-                        expect(controller.getHttpVaryParams().length).to.equal(0);
-                        var ctl = controller.addHttpVaryParam('user-agent');
-
-                        var params = controller.getHttpVaryParams();
-                        expect(params.length).to.equal(1);
-                        expect(params[0]).to.equal('user-agent');
-                        expect(ctl == controller).to.be.true;
+                        controller.ctx.addHttpVaryParam = sinon.stub();
+                        controller.addHttpVaryParam('accept');
+                        expect(controller.ctx.addHttpVaryParam.calledOnce).to.be.true;
 
                         dfd.resolve();
                     },
@@ -72,15 +101,26 @@ define([
                 getController({
                     success: function (controller) {
 
-                        expect(controller.getHttpHeaders().length).to.equal(0);
-                        var ctl = controller.addHttpHeader('X-Frame-Options', 'deny');
+                        controller.ctx.addHttpHeader = sinon.stub();
+                        controller.addHttpHeader('X-Frame-Options', 'deny');
+                        expect(controller.ctx.addHttpHeader.calledOnce).to.be.true;
 
-                        var headers = controller.getHttpHeaders();
-                        expect(headers.length).to.equal(1);
-                        expect(headers[0].name).to.equal('X-Frame-Options');
-                        expect(headers[0].value).to.equal('deny');
-                        expect(headers[0].options).to.equal(null);
-                        expect(ctl == controller).to.be.true;
+                        dfd.resolve();
+                    },
+                    error: function () {
+                        dfd.reject();
+                    }
+                });
+            });
+
+            it('should get http headers', function () {
+                var dfd = this.async();
+                getController({
+                    success: function (controller) {
+
+                        controller.ctx.getHttpHeaders = sinon.stub();
+                        controller.getHttpHeaders();
+                        expect(controller.ctx.getHttpHeaders.calledOnce).to.be.true;
 
                         dfd.resolve();
                     },


### PR DESCRIPTION
Similar to #273, allow http response data to be modified for tunnel requests.
Refactor the httpResponse to the context, reuse in controller and syncher
Refactor the context class to retain server only behavior on the server

The interface is exactly the same as for HTTP response data on controllers, except that the tunnel HTTP response data must be set using a syncher instance:

```javascript
// within a syncher function
this.setHttpStatusCode(500);
this.getHttpStatusCode();
this.addHttpHeader('allow', 'GET');
this.getHttpHeaders();
this.addHttpVaryParam('accept');
this.getHttpVaryParams();
```

When these functions are executed as part of an initial page request where the page is rendered on the server, these functions will have no impact on the response. They will only impact the response from a tunnel request.

Currently, there is no application level functionality for adding tunnel response HTTP data. If required, this would not be difficult to implement.

Let me know if you have any questions. Adam.